### PR TITLE
Set real-time GPU priority in SwapChainProcessor

### DIFF
--- a/DVServerUMD/DVServer/Driver.cpp
+++ b/DVServerUMD/DVServer/Driver.cpp
@@ -732,6 +732,16 @@ void SwapChainProcessor::RunCore()
 		return;
 	}
 
+	if (IDD_IS_FUNCTION_AVAILABLE(IddCxSetRealtimeGPUPriority))
+	{
+		IDARG_IN_SETREALTIMEGPUPRIORITY SetPriority = {};
+		SetPriority.pDevice = DxgiDevice.Get();
+		hr = IddCxSetRealtimeGPUPriority(m_hSwapChain, &SetPriority);
+		if (FAILED(hr)) {
+			ERR("IddCxSetRealtimeGPUPriority failed\n");
+		} 
+	}
+
 	IDARG_IN_SWAPCHAINSETDEVICE SetDevice = {};
 	SetDevice.pDevice = DxgiDevice.Get();
 


### PR DESCRIPTION
**Problem: Low Display Update Rate Under High GPU Load**
Under high GPU load, the display driver can become starved of GPU resources, resulting in a low display update rate and visible stuttering, even when the application rendering 3D content maintains a high frame rate. Focusing the application window that generates high GPU load worsens the issue due to Windows prioritizing its GPU usage.

[Screencast_20250731_090349.webm](https://github.com/user-attachments/assets/86c26c9a-9431-4878-8eee-a9dcee809d2c)


**Steps to Reproduce**

1. Launch [FurMark 2](https://geeks3d.com/furmark/downloads/).
2. Ensure the FurMark window is focused (this is important, as Windows will prioritize rendering for the focused application).
3. Observe that while FurMark maintains a high FPS, the desktop display update rate drops significantly and exhibits stuttering.

**Proposed Fix**
Set the display driver's GPU thread to real-time priority using [IddCxSetRealtimeGPUPriority](https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/iddcx/nf-iddcx-iddcxsetrealtimegpupriority). This ensures that the Idd receives adequate GPU resources to maintain a consistent and smooth output.
