### PR TITLE
Add VIRTIO_GPU_FLAG_FENCE to resource flush command header

### DIFF
--- a/DVServerKMD/viogpu_queue.cpp
+++ b/DVServerKMD/viogpu_queue.cpp
@@ -504,6 +504,7 @@ void CtrlQueue::ResFlush(UINT res_id, UINT width, UINT height, UINT x, UINT y, U
 	RtlZeroMemory(cmd, sizeof(*cmd));
 
 	cmd->hdr.type = VIRTIO_GPU_CMD_RESOURCE_FLUSH;
+	cmd->hdr.flags |= VIRTIO_GPU_FLAG_FENCE;
 	cmd->hdr.fence_id = screen_num;
 	cmd->resource_id = res_id;
 	cmd->r.width = width;


### PR DESCRIPTION
**Problem: Upstream QEMU display corruption**
Using the Display-Virtualization-for-Windows-OS with the current upstream QEMU causes display issues as seen in this picture:
<img width="2010" height="1224" alt="image" src="https://github.com/user-attachments/assets/65bf0299-71fe-42b4-a5af-5198ae4de17a" />

I tracked it down to this commit in QEMU: [virtio-gpu: Support suspension of commands processing](https://gitlab.com/qemu-project/qemu/-/commit/640f9149c3dcafbfeb495a10f6105c6f71f24d1d)

**Proposed Fix**
Set the VIRTIO_GPU_FLAG_FENCE in the VIRTIO_GPU_CMD_RESOURCE_FLUSH command, since it already has a fence_id. I am not sure if it was intended to not set this flag or an oversight.